### PR TITLE
Fix horizontal scroll on mobile in Fresh Reviews section

### DIFF
--- a/mini-app/src/index.css
+++ b/mini-app/src/index.css
@@ -19,6 +19,8 @@ body {
   background-color: var(--tg-theme-bg-color, #ffffff);
   color: var(--tg-theme-text-color, #000000);
   font-family: 'Ubuntu', system-ui, -apple-system, sans-serif;
+  overflow-x: hidden;
+  word-break: break-word;
 }
 
 * {


### PR DESCRIPTION
Added overflow-x: hidden and word-break: break-word to body in CSS
to prevent unwanted horizontal scrolling on mobile devices when
viewing the reviews section.

https://claude.ai/code/session_01XucECkfuwUGHui4JNDM6aj