### PR TITLE
[codex] Add subscription banner activation flow

### DIFF
--- a/mini-app/src/App.tsx
+++ b/mini-app/src/App.tsx
@@ -13,6 +13,7 @@ import FreshReviews from "./pages/FreshReviews";
 import PopularAuthors from "./pages/PopularAuthors.js";
 import AuthorBooks from "./pages/AuthorBooks.js";
 import VolunteerScreen from "./pages/VolunteerScreen";
+import Subscribe from "./pages/Subscribe";
 import { TABBED_ROUTES } from "./lib/routes.js";
 
 // Create context for config
@@ -148,6 +149,7 @@ function AppContent() {
       <Route path="/author/:author" element={<Layout><AuthorBooks /></Layout>} />
       <Route path="/fresh-reviews" element={<Layout><FreshReviews /></Layout>} />
       <Route path="/volunteer" element={<Layout><VolunteerScreen /></Layout>} />
+      <Route path="/subscribe" element={<Layout><Subscribe /></Layout>} />
       {/* Legacy route for backward compatibility */}
       <Route path="/leaderboard" element={<Layout><Leaderboard /></Layout>} />
     </Routes>

--- a/mini-app/src/api/client.ts
+++ b/mini-app/src/api/client.ts
@@ -484,6 +484,12 @@ export async function getConfig(): Promise<Config> {
   return fetchApi("/config");
 }
 
+export async function activateSubscription(): Promise<{ isActive: true }> {
+  return fetchApi("/subscriptions/activate", {
+    method: "POST",
+  });
+}
+
 export function isCurrentUserAdmin(adminUserIds: string[]): boolean {
   const userId = getCurrentUserId();
   if (!userId) return false;

--- a/mini-app/src/components/Layout.tsx
+++ b/mini-app/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import Header from "./Header.js";
+import SubscriptionBanner from "./SubscriptionBanner.js";
 
 interface LayoutProps {
   children: ReactNode;
@@ -10,6 +11,7 @@ export default function Layout({ children, shareUrl }: LayoutProps) {
   return (
     <div className="min-h-screen bg-tg-bg flex flex-col">
       <Header shareUrl={shareUrl} />
+      <SubscriptionBanner />
       <main className="flex-1">{children}</main>
     </div>
   );

--- a/mini-app/src/components/SubscriptionBanner.tsx
+++ b/mini-app/src/components/SubscriptionBanner.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { activateSubscription } from "../api/client.js";
+import Toast from "./Toast.js";
+import { useToast } from "../hooks/useToast.js";
+
+export default function SubscriptionBanner() {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const { message, showToast } = useToast();
+
+  const handleClick = async () => {
+    const tg = window.Telegram?.WebApp;
+
+    if (!tg?.initData) {
+      navigate("/subscribe");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await activateSubscription();
+      showToast("Подписка включена");
+    } catch {
+      navigate("/subscribe");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isLoading}
+        aria-label="Подписаться на новые рецензии"
+        className="mx-4 my-3 flex w-[calc(100%-2rem)] items-center gap-2 rounded-md border border-dashed border-[#d97706] bg-[#fff7ed] px-3 py-2 text-left text-sm font-normal text-[#7c2d12] transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-70"
+      >
+        <span aria-hidden="true" className="text-base leading-none">
+          💬
+        </span>
+        <span>Подпишись на новые рецензии прямо в личку!</span>
+      </button>
+      {message && <Toast message={message} />}
+    </>
+  );
+}

--- a/mini-app/src/pages/Book.tsx
+++ b/mini-app/src/pages/Book.tsx
@@ -101,19 +101,19 @@ export default function Book() {
     navigate("/browse");
   };
 
-  if (loading) return <Loading />;
-  if (error) return <ErrorMessage message={error} />;
-  if (!book) return <ErrorMessage message={t("book.notFound")} />;
+  const shareUrl = config?.botUsername && book
+    ? getBookDeepLink(config.botUsername, book.id)
+    : undefined;
+
+  if (loading) return <Layout shareUrl={shareUrl}><Loading /></Layout>;
+  if (error) return <Layout shareUrl={shareUrl}><ErrorMessage message={error} /></Layout>;
+  if (!book) return <Layout shareUrl={shareUrl}><ErrorMessage message={t("book.notFound")} /></Layout>;
 
   const filteredReviews = sentimentFilter
     ? reviews.filter((r) => r.sentiment === sentimentFilter)
     : reviews;
 
   const { positive, negative, neutral } = book.sentiments;
-
-  const shareUrl = config?.botUsername && book
-    ? getBookDeepLink(config.botUsername, book.id)
-    : undefined;
 
   return (
     <Layout shareUrl={shareUrl}>

--- a/mini-app/src/pages/Review.tsx
+++ b/mini-app/src/pages/Review.tsx
@@ -41,9 +41,9 @@ export default function Review() {
     ? getReviewDeepLink(config.botUsername, review.id)
     : undefined;
 
-  if (loading) return <Loading />;
-  if (error) return <ErrorMessage message={error} />;
-  if (!review) return <ErrorMessage message="Рецензия не найдена" />;
+  if (loading) return <Layout shareUrl={shareUrl}><Loading /></Layout>;
+  if (error) return <Layout shareUrl={shareUrl}><ErrorMessage message={error} /></Layout>;
+  if (!review) return <Layout shareUrl={shareUrl}><ErrorMessage message="Рецензия не найдена" /></Layout>;
 
   return (
     <Layout shareUrl={shareUrl}>

--- a/mini-app/src/pages/Reviewer.tsx
+++ b/mini-app/src/pages/Reviewer.tsx
@@ -73,16 +73,16 @@ export default function Reviewer() {
     }
   };
 
-  if (loading) return <Loading />;
-  if (error) return <ErrorMessage message={error} />;
-  if (!reviewer) return <ErrorMessage message={t("reviewer.notFound")} />;
-
-  const displayName = reviewer.displayName || reviewer.username || t("common.anonymous");
-  const { positive, negative, neutral } = reviewer.sentiments;
-
   const shareUrl = config?.botUsername && userId
     ? getReviewerDeepLink(config.botUsername, userId)
     : undefined;
+
+  if (loading) return <Layout shareUrl={shareUrl}><Loading /></Layout>;
+  if (error) return <Layout shareUrl={shareUrl}><ErrorMessage message={error} /></Layout>;
+  if (!reviewer) return <Layout shareUrl={shareUrl}><ErrorMessage message={t("reviewer.notFound")} /></Layout>;
+
+  const displayName = reviewer.displayName || reviewer.username || t("common.anonymous");
+  const { positive, negative, neutral } = reviewer.sentiments;
 
   return (
     <Layout shareUrl={shareUrl}>

--- a/mini-app/src/pages/Subscribe.tsx
+++ b/mini-app/src/pages/Subscribe.tsx
@@ -1,0 +1,18 @@
+export default function Subscribe() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-3 text-xl font-bold text-tg-text">Подписка на рецензии</h1>
+      <p className="text-sm font-normal leading-6 text-tg-hint">
+        Чтобы получать новые рецензии в личку, открой личные сообщения{" "}
+        <a
+          href="https://t.me/vas3k_book_bot"
+          className="text-tg-text underline"
+        >
+          нашего бота
+        </a>
+        , отправь команду <span className="font-mono text-tg-text">/start</span>, а затем{" "}
+        <span className="font-mono text-tg-text">/subscribe</span>.
+      </p>
+    </div>
+  );
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,34 +8,39 @@ import authorsRouter from "./routes/authors.js";
 import volunteerRouter from "./routes/volunteer.js";
 import searchRouter from "./routes/search.js";
 import digestRouter from "./routes/digest.js";
+import { createSubscriptionsRouter } from "./routes/subscriptions.js";
 import { getStats } from "../services/review.service.js";
+import type { Telegraf } from "telegraf";
 
-const router = Router();
+export function createApiRouter(bot: Telegraf) {
+  const router = Router();
 
-router.use("/books", booksRouter);
-router.use("/reviewers", reviewersRouter);
-router.use("/reviews", reviewsRouter);
-router.use("/leaderboard", leaderboardRouter);
-router.use("/config", configRouter);
-router.use("/authors", authorsRouter);
-router.use("/volunteer", volunteerRouter);
-router.use("/search", searchRouter);
-router.use("/digest", digestRouter);
+  router.use("/books", booksRouter);
+  router.use("/reviewers", reviewersRouter);
+  router.use("/reviews", reviewsRouter);
+  router.use("/leaderboard", leaderboardRouter);
+  router.use("/config", configRouter);
+  router.use("/authors", authorsRouter);
+  router.use("/volunteer", volunteerRouter);
+  router.use("/search", searchRouter);
+  router.use("/digest", digestRouter);
+  router.use("/subscriptions", createSubscriptionsRouter(bot));
 
-// Health check
-router.get("/health", (req, res) => {
-  res.json({ status: "ok", timestamp: new Date().toISOString() });
-});
+  // Health check
+  router.get("/health", (req, res) => {
+    res.json({ status: "ok", timestamp: new Date().toISOString() });
+  });
 
-// Stats endpoint
-router.get("/stats", async (req, res) => {
-  try {
-    const stats = await getStats();
-    res.json(stats);
-  } catch (error) {
-    console.error("Error fetching stats:", error);
-    res.status(500).json({ error: "Failed to fetch stats" });
-  }
-});
+  // Stats endpoint
+  router.get("/stats", async (req, res) => {
+    try {
+      const stats = await getStats();
+      res.json(stats);
+    } catch (error) {
+      console.error("Error fetching stats:", error);
+      res.status(500).json({ error: "Failed to fetch stats" });
+    }
+  });
 
-export default router;
+  return router;
+}

--- a/src/api/routes/subscriptions.ts
+++ b/src/api/routes/subscriptions.ts
@@ -1,0 +1,59 @@
+import { Router } from "express";
+import type { Telegraf } from "telegraf";
+import { activateSubscription } from "../../services/subscription.service.js";
+import { authenticateTelegramWebApp } from "../middleware/telegram-auth.js";
+
+const PRIVATE_CHAT_REQUIRED_CODE = "BOT_PRIVATE_CHAT_REQUIRED";
+
+function isPrivateChatUnavailableError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+
+  return (
+    message.includes("403") ||
+    message.includes("400") ||
+    message.includes("blocked") ||
+    message.includes("bot was blocked") ||
+    message.includes("chat not found") ||
+    message.includes("user is deactivated") ||
+    message.includes("forbidden")
+  );
+}
+
+export function createSubscriptionsRouter(bot: Telegraf) {
+  const router = Router();
+
+  router.post("/activate", authenticateTelegramWebApp, async (req, res) => {
+    try {
+      const telegramUserId = req.telegramUser?.id;
+
+      if (!telegramUserId) {
+        res.status(401).json({ error: "Missing Telegram user" });
+        return;
+      }
+
+      try {
+        await bot.telegram.sendChatAction(telegramUserId.toString(), "typing");
+      } catch (error) {
+        if (isPrivateChatUnavailableError(error)) {
+          res.status(409).json({
+            error: "Bot private chat required",
+            code: PRIVATE_CHAT_REQUIRED_CODE,
+          });
+          return;
+        }
+
+        throw error;
+      }
+
+      const subscription = await activateSubscription(telegramUserId);
+
+      res.json(subscription);
+    } catch (error) {
+      console.error("Error activating subscription:", error);
+      res.status(500).json({ error: "Failed to activate subscription" });
+    }
+  });
+
+  return router;
+}
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { Telegraf } from "telegraf";
 import { config } from "./lib/config.js";
-import apiRouter from "./api/index.js";
+import { createApiRouter } from "./api/index.js";
 import {
   createAuthenticateTelegramWebApp,
   setAuthMiddleware,
@@ -38,7 +38,7 @@ export function createServer(bot: Telegraf) {
   }
 
   // API routes
-  app.use("/api", apiRouter);
+  app.use("/api", createApiRouter(bot));
 
   // Serve mini-app static files in production
   if (!config.isDev) {

--- a/src/services/subscription.service.ts
+++ b/src/services/subscription.service.ts
@@ -22,6 +22,21 @@ export async function createSubscription(
 }
 
 /**
+ * Activate a user's subscription without toggling active subscriptions off
+ */
+export async function activateSubscription(
+  telegramUserId: bigint
+): Promise<{ isActive: true }> {
+  await prisma.subscription.upsert({
+    where: { telegramUserId },
+    create: { telegramUserId },
+    update: { isActive: true },
+  });
+
+  return { isActive: true };
+}
+
+/**
  * Toggle a user's subscription status
  * Creates subscription if it doesn't exist, otherwise toggles isActive
  * Returns the new subscription state

--- a/test/api/subscriptions.test.ts
+++ b/test/api/subscriptions.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createSubscriptionsRouter } from "../../src/api/routes/subscriptions.js";
+import { setAuthMiddleware } from "../../src/api/middleware/telegram-auth.js";
+import { activateSubscription } from "../../src/services/subscription.service.js";
+
+vi.mock("../../src/services/subscription.service.js", () => ({
+  activateSubscription: vi.fn(),
+}));
+
+function createApp(bot: any) {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/subscriptions", createSubscriptionsRouter(bot));
+  return app;
+}
+
+describe("POST /api/subscriptions/activate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require Telegram auth", async () => {
+    setAuthMiddleware((req, res) => {
+      res.status(401).json({ error: "Missing or invalid Authorization header" });
+    });
+
+    const bot = {
+      telegram: {
+        sendChatAction: vi.fn(),
+      },
+    };
+
+    const response = await request(createApp(bot)).post("/api/subscriptions/activate");
+
+    expect(response.status).toBe(401);
+    expect(bot.telegram.sendChatAction).not.toHaveBeenCalled();
+    expect(activateSubscription).not.toHaveBeenCalled();
+  });
+
+  it("should activate subscription when bot can message the user", async () => {
+    setAuthMiddleware((req, res, next) => {
+      req.telegramUser = { id: BigInt(12345) };
+      next();
+    });
+
+    const bot = {
+      telegram: {
+        sendChatAction: vi.fn().mockResolvedValue(true),
+      },
+    };
+    vi.mocked(activateSubscription).mockResolvedValue({ isActive: true });
+
+    const response = await request(createApp(bot)).post("/api/subscriptions/activate");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ isActive: true });
+    expect(bot.telegram.sendChatAction).toHaveBeenCalledWith("12345", "typing");
+    expect(activateSubscription).toHaveBeenCalledWith(BigInt(12345));
+  });
+
+  it("should return fallback response when private chat is unavailable", async () => {
+    setAuthMiddleware((req, res, next) => {
+      req.telegramUser = { id: BigInt(12345) };
+      next();
+    });
+
+    const bot = {
+      telegram: {
+        sendChatAction: vi
+          .fn()
+          .mockRejectedValue(new Error("403: Forbidden: bot was blocked by the user")),
+      },
+    };
+
+    const response = await request(createApp(bot)).post("/api/subscriptions/activate");
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual({
+      error: "Bot private chat required",
+      code: "BOT_PRIVATE_CHAT_REQUIRED",
+    });
+    expect(activateSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/subscription-service.test.ts
+++ b/test/unit/subscription-service.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   getSubscription,
   createSubscription,
+  activateSubscription,
   toggleSubscription,
   getActiveSubscribers,
   getSubscriberCount,
@@ -19,6 +20,7 @@ vi.mock("../../src/lib/prisma.js", () => ({
       findUnique: vi.fn(),
       findMany: vi.fn(),
       create: vi.fn(),
+      upsert: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn(),
       count: vi.fn(),
@@ -76,6 +78,46 @@ describe("Subscription Service", () => {
       expect(result).toEqual({ isActive: true });
       expect(prisma.subscription.create).toHaveBeenCalledWith({
         data: { telegramUserId: BigInt(123456) },
+      });
+    });
+  });
+
+  describe("activateSubscription", () => {
+    it("should create missing subscription as active", async () => {
+      vi.mocked(prisma.subscription.upsert).mockResolvedValue({
+        id: 1,
+        telegramUserId: BigInt(123456),
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await activateSubscription(BigInt(123456));
+
+      expect(result).toEqual({ isActive: true });
+      expect(prisma.subscription.upsert).toHaveBeenCalledWith({
+        where: { telegramUserId: BigInt(123456) },
+        create: { telegramUserId: BigInt(123456) },
+        update: { isActive: true },
+      });
+    });
+
+    it("should reactivate inactive subscription without toggling off", async () => {
+      vi.mocked(prisma.subscription.upsert).mockResolvedValue({
+        id: 1,
+        telegramUserId: BigInt(123456),
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await activateSubscription(BigInt(123456));
+
+      expect(result).toEqual({ isActive: true });
+      expect(prisma.subscription.upsert).toHaveBeenCalledWith({
+        where: { telegramUserId: BigInt(123456) },
+        create: { telegramUserId: BigInt(123456) },
+        update: { isActive: true },
       });
     });
   });


### PR DESCRIPTION
Adds a mini-app subscription banner that lets Telegram WebApp users activate review notifications directly. Introduces an authenticated `/api/subscriptions/activate` endpoint that checks whether the bot can reach the user before idempotently enabling the subscription. Adds a fallback `/subscribe` page and keeps detail-page loading/error states inside the shared layout so the banner and header remain visible. Validated with `npm run typecheck`, targeted subscription tests, `mini-app` production build, and the full backend test suite.